### PR TITLE
Offer autologin only if a display manager that supports it is installed

### DIFF
--- a/package/yast2-pam.changes
+++ b/package/yast2-pam.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Apr 16 12:39:31 UTC 2019 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Offer autologin only if a display manager that supports it is
+  installed (bsc#1128385) 
+- 4.1.1
+
+-------------------------------------------------------------------
 Tue Feb 26 12:05:42 UTC 2019 - José Iván López González <jlopez@suse.com>
 
 - Version bump (bsc#1124009)

--- a/package/yast2-pam.changes
+++ b/package/yast2-pam.changes
@@ -3,7 +3,7 @@ Tue Apr 16 12:39:31 UTC 2019 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Offer autologin only if a display manager that supports it is
   installed (bsc#1128385) 
-- 4.1.1
+- 4.2.0
 
 -------------------------------------------------------------------
 Tue Feb 26 12:05:42 UTC 2019 - José Iván López González <jlopez@suse.com>

--- a/package/yast2-pam.spec
+++ b/package/yast2-pam.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pam
-Version:        4.1.0
+Version:        4.1.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-pam.spec
+++ b/package/yast2-pam.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pam
-Version:        4.1.1
+Version:        4.2.0
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
# Trello

https://trello.com/c/VVM2ib4G/

# Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1128385 (openSUSE)
https://bugzilla.suse.com/show_bug.cgi?id=1060173 (SLES)

# Related PR

https://github.com/yast/yast-users/pull/205

# Problem

During installation and later in the installed system, "autologin" is offered even if it doesn't make sense and if it can't even work: If a user selects the "server" role or some other package combination that does not provide X11 or Wayland or, in general, a graphical login, the "Autologin" checkbox is available.

Selecting that option has no effect in that case.

# Fix

Don't only rely on the control.xml file that has a parameter if that should be offered at all; also check if the capability is available, i.e. if a display manager (login manager) that supports that feature is or will be installed.

## Pragmatic Approach

Use a fixed package list to check against:

- kdm
- gdm
- sddm
- lightdm

_Not "xdm"; it does not support that!_

**Downside:** We have to maintain that list in the code. We might not be notified when a new display manager is added to the distribution (which fortunately does not happen very often).

## In an Ideal World

Make sure the packages have a special `provides` to indicate that they provide that feature; like `autologin-support`.

That would mean to provide the infrastructure to check for that in the YaST code, but ask the maintainers of those display managers to add that `provides` to the package.

Still, if some day a new display manager is added to the distribution, the maintainer of that new display manager might now know of that special `provides`; then it would probably take a while for users (and for our QA) to realize that the autologin feature is missing when using that display manager (and not installing another one, too), and they would write a bug report against YaST which we'd have to process, debug and ultimately reassign to the maintainer of that new display manager telling him exactly what to add to his .spec file. 

## Chosen Approach

Do both; add the fixed list to the code, but _also_ that pseudo-`provides`, so display manager packages can gradually be extended with it. That should cover both fronts.

# Test

## Installed System

- Start "yast2 users" and

  - Check /var/log/YaST2/y2log for "Autologin is supported" or "Autologin is not supported"
  - On the main dialog of the users module, check the "Expert Options" menu whether or not there is a menu entry "Login Settings" (this is only about autologin)

You might need to modify the package list in `/usr/share/YaST2/modules/Autologin.rb` to test the other case.


## inst-sys

(this also requires https://github.com/yast/yast-users/pull/205)

- Start the installation
- Select system role "Server" (or another role without graphical desktop)
- Continue to the "Create First User" dialog
- Check if the "Autologin" checkbox in that dialog is really disabled

- Go back to the role selection
- Select another role, this time _with_ a graphical desktop
- Continue to the "Create First User" dialog
- Check if the "Autologin" checkbox is enabled now

# Maintainers of Display Managers

Add this to your .spec file:

```spec
provides: autologin-support
```