### PR TITLE
Fixed broken unit tests in yast2-users and yast2-nis-client

### DIFF
--- a/package/yast2-pam.changes
+++ b/package/yast2-pam.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Apr 17 18:44:23 UTC 2019 - Ladislav Slezak <lslezak@suse.cz>
+
+- Skip loading the package manager in the test mode, fixes
+  broken unit tests in yast2-users and yast2-nis-client
+  (related to the previous fix bsc#1128385)
+- 4.2.1
+
+-------------------------------------------------------------------
 Tue Apr 16 12:39:31 UTC 2019 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Offer autologin only if a display manager that supports it is

--- a/package/yast2-pam.spec
+++ b/package/yast2-pam.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pam
-Version:        4.2.0
+Version:        4.2.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/Autologin.rb
+++ b/src/modules/Autologin.rb
@@ -195,10 +195,12 @@ module Yast
       # We don't strictly need any package callbacks here, but libzypp might
       # report an error, and then there would be no user feedback.
       PackageCallbacks.InitPackageCallbacks
-      Pkg.TargetInitialize("/")
+      # FIXME: Mode.test workaround for the old testsuite to not break the other modules
+      Pkg.TargetInitialize("/") unless Mode.test
 
       # Add the installed system to the libzypp pool
-      Pkg.TargetLoad
+      # FIXME: Mode.test workaround for the old testsuite to not break the other modules
+      Pkg.TargetLoad unless Mode.test
 
       @pkg_initialized = true
     end


### PR DESCRIPTION
- Simple and stupid fix for breaking tests in `yast2-users` and `yast2-nis-client`
- Not a nice solution but fixing the old tests is really challenging
- Tested manually, both `yast2-users` and `yast2-nis-client` build properly against the updated package
- Related to the previous fix for bsc#1128385
- 4.2.1