### PR TITLE
Autologin Fix: Init Pkg Target with Installation.destdir, not "/"

### DIFF
--- a/package/yast2-pam.changes
+++ b/package/yast2-pam.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue May 14 10:14:04 UTC 2019 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Init pkg target with Installation.destdir, not "/" (bsc#1133541)
+- 4.2.2
+
+-------------------------------------------------------------------
 Wed Apr 17 18:44:23 UTC 2019 - Ladislav Slezak <lslezak@suse.cz>
 
 - Skip loading the package manager in the test mode, fixes

--- a/package/yast2-pam.spec
+++ b/package/yast2-pam.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pam
-Version:        4.2.1
+Version:        4.2.2
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/Autologin.rb
+++ b/src/modules/Autologin.rb
@@ -47,6 +47,7 @@ module Yast
       Yast.import "Popup"
       Yast.import "Pkg"
       Yast.import "PackageCallbacks"
+      Yast.import "Installation"
 
       # User to log in automaticaly
       @user = ""
@@ -196,7 +197,7 @@ module Yast
       # report an error, and then there would be no user feedback.
       PackageCallbacks.InitPackageCallbacks
       # FIXME: Mode.test workaround for the old testsuite to not break the other modules
-      Pkg.TargetInitialize("/") unless Mode.test
+      Pkg.TargetInitialize(Installation.destdir) unless Mode.test
 
       # Add the installed system to the libzypp pool
       # FIXME: Mode.test workaround for the old testsuite to not break the other modules


### PR DESCRIPTION
# Trello

https://trello.com/c/nocDY5Kc/

# Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1133541

# Problem

No autologin after AutoYaST installation, even if installing a rich desktop like GNOME or KDE.

# Cause

`Pkg.TargetInitialize()` was called with `"/"`, but in this scenario it needs `Installation.destdir`.

# Related PR

https://github.com/yast/yast-pam/pull/13

# Test

Manual test by @schubi2 (Thanks!)