### PR TITLE
Fixed missing GPG keys (bsc#1135295)

### DIFF
--- a/package/yast2-pam.changes
+++ b/package/yast2-pam.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu May 16 11:06:32 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Fixed packager initialization (fixes missing GPG keys in the
+  installed system) (bsc#1135295)
+- 4.2.3
+
+-------------------------------------------------------------------
 Tue May 14 10:14:04 UTC 2019 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Init pkg target with Installation.destdir, not "/" (bsc#1133541)

--- a/package/yast2-pam.spec
+++ b/package/yast2-pam.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-pam
-Version:        4.2.2
+Version:        4.2.3
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/Autologin.rb
+++ b/src/modules/Autologin.rb
@@ -48,6 +48,7 @@ module Yast
       Yast.import "Pkg"
       Yast.import "PackageCallbacks"
       Yast.import "Installation"
+      Yast.import "Stage"
 
       # User to log in automaticaly
       @user = ""
@@ -191,7 +192,9 @@ module Yast
 
     # Initialize the pkg subsystem
     def pkg_lazy_init
-      return if @pkg_initialized
+      # do not initialize the package manager when running in inst-sys,
+      # it is initialized by the installation framework (bsc#1135295)
+      return if Stage.initial || @pkg_initialized
 
       # We don't strictly need any package callbacks here, but libzypp might
       # report an error, and then there would be no user feedback.


### PR DESCRIPTION
- See https://bugzilla.suse.com/show_bug.cgi?id=1135295
- The problem is in the `Pkg.TargetInitialize(Installation.destdir)` call - in that call libzypp also saves the imported GPG keys into the target system.
- However, in this case the target initialization was called too early, at that point the `/mnt` mount point is still in the inst-sys RAM disk. The GPG keys are saved into the inst-sys and later the `/mnt` content is hidden  by mounting the target partition there.
- Tested manually, the autologin capability detection works correctly in the installation and it is correctly enabled in the installed system. And the GPG keys are present in the installed system.
- 4.2.3