### PR TITLE
Added function to query PAM modules (bsc#1171318)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,144 @@
+# use the shared YaST defaults
+inherit_from:
+  /usr/share/YaST2/data/devtools/data/rubocop-0.71.0_yast_style.yml
+
+# Offense count: 1
+# Cop supports --auto-correct.
+Layout/EmptyLineAfterGuardClause:
+  Exclude:
+    - 'src/modules/Pam.rb'
+
+# Offense count: 2
+# Cop supports --auto-correct.
+# Configuration parameters: AllowAdjacentOneLineDefs, NumberOfEmptyLines.
+Layout/EmptyLineBetweenDefs:
+  Exclude:
+    - 'src/modules/Autologin.rb'
+    - 'src/modules/Nsswitch.rb'
+
+# Offense count: 3
+# Cop supports --auto-correct.
+Layout/EmptyLines:
+  Exclude:
+    - 'src/modules/Autologin.rb'
+    - 'src/modules/Nsswitch.rb'
+
+# Offense count: 15
+# Cop supports --auto-correct.
+# Configuration parameters: IndentationWidth.
+Layout/Tab:
+  Exclude:
+    - 'src/modules/Autologin.rb'
+    - 'src/modules/Nsswitch.rb'
+    - 'src/modules/Pam.rb'
+
+# Offense count: 1
+Lint/ShadowingOuterLocalVariable:
+  Exclude:
+    - 'src/modules/Pam.rb'
+
+# Offense count: 1
+# Cop supports --auto-correct.
+# Configuration parameters: AllowUnusedKeywordArguments, IgnoreEmptyMethods.
+Lint/UnusedMethodArgument:
+  Exclude:
+    - 'src/modules/Autologin.rb'
+
+# Offense count: 5
+# Configuration parameters: CountComments, ExcludedMethods.
+# ExcludedMethods: refine
+Metrics/BlockLength:
+  Max: 120
+
+# Offense count: 3
+# Configuration parameters: ExpectMatchingDefinition, Regex, IgnoreExecutableScripts, AllowedAcronyms.
+# AllowedAcronyms: CLI, DSL, ACL, API, ASCII, CPU, CSS, DNS, EOF, GUID, HTML, HTTP, HTTPS, ID, IP, JSON, LHS, QPS, RAM, RHS, RPC, SLA, SMTP, SQL, SSH, TCP, TLS, TTL, UDP, UI, UID, UUID, URI, URL, UTF8, VM, XML, XMPP, XSRF, XSS
+Naming/FileName:
+  Exclude:
+    - 'src/modules/Autologin.rb'
+    - 'src/modules/Nsswitch.rb'
+    - 'src/modules/Pam.rb'
+
+# Offense count: 16
+# Configuration parameters: .
+# SupportedStyles: snake_case, camelCase
+Naming/MethodName:
+  Exclude:
+    - 'src/modules/Nsswitch.rb'
+    - 'src/modules/Autologin.rb'
+    - 'src/modules/Pam.rb'
+
+# Offense count: 6
+Style/Documentation:
+  Exclude:
+    - 'spec/**/*'
+    - 'test/**/*'
+    - 'src/modules/Autologin.rb'
+    - 'src/modules/Nsswitch.rb'
+    - 'src/modules/Pam.rb'
+
+# Cop supports --auto-correct.
+# Configuration parameters: EnforcedStyle.
+# SupportedStyles: compact, expanded
+Style/EmptyMethod:
+  Exclude:
+    - 'src/modules/Pam.rb'
+
+# Offense count: 3
+# Cop supports --auto-correct.
+Style/Encoding:
+  Exclude:
+    - 'src/modules/Autologin.rb'
+    - 'src/modules/Nsswitch.rb'
+    - 'src/modules/Pam.rb'
+
+# Offense count: 8
+# Cop supports --auto-correct.
+# Configuration parameters: EnforcedStyle.
+# SupportedStyles: always, never
+Style/FrozenStringLiteralComment:
+  Exclude:
+    - 'Rakefile'
+    - 'src/lib/cfa/nsswitch.rb'
+    - 'src/modules/Autologin.rb'
+    - 'src/modules/Nsswitch.rb'
+    - 'src/modules/Pam.rb'
+    - 'test/cfa/nsswitch_test.rb'
+    - 'test/nsswitch_test.rb'
+    - 'test/test_helper.rb'
+
+# Offense count: 1
+# Configuration parameters: MinBodyLength.
+Style/GuardClause:
+  Exclude:
+    - 'src/lib/cfa/nsswitch.rb'
+
+# Offense count: 43
+# Cop supports --auto-correct.
+# Configuration parameters: EnforcedStyle, UseHashRocketsWithSymbolValues, PreferHashRocketsForNonAlnumEndingSymbols.
+# SupportedStyles: ruby19, hash_rockets, no_mixed_keys, ruby19_no_mixed_keys
+Style/HashSyntax:
+  Exclude:
+    - 'src/modules/Autologin.rb'
+    - 'src/modules/Nsswitch.rb'
+    - 'src/modules/Pam.rb'
+
+# Offense count: 2
+# Cop supports --auto-correct.
+Style/LineEndConcatenation:
+  Exclude:
+    - 'src/modules/Autologin.rb'
+
+# Offense count: 1
+# Cop supports --auto-correct.
+# Configuration parameters: EnforcedStyle.
+# SupportedStyles: predicate, comparison
+Style/NilComparison:
+  Exclude:
+    - 'src/modules/Autologin.rb'
+
+# Offense count: 1
+# Cop supports --auto-correct.
+Style/RedundantBegin:
+  Exclude:
+    - 'test/nsswitch_test.rb'

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 require "yast/rake"
 
 Yast::Tasks.configuration do |conf|
-  #lets ignore license check for now
+  # lets ignore license check for now
   conf.skip_license_check << /.*/
 end

--- a/package/yast2-pam.changes
+++ b/package/yast2-pam.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jul 28 11:03:14 CEST 2020 - aschnell@suse.com
+
+- Added function to query PAM modules (bsc#1171318).
+- 4.3.1
+
+-------------------------------------------------------------------
 Fri Jul 24 11:01:03 UTC 2020 - David Diaz <dgonzalez@suse.com>
 
 - Support reading nsswitch.conf from /usr/etc  (bsc#1173119).

--- a/package/yast2-pam.spec
+++ b/package/yast2-pam.spec
@@ -16,7 +16,7 @@
 #
 
 Name:          yast2-pam
-Version:       4.3.0
+Version:       4.3.1
 Release:       0
 Summary:       YaST2 - PAM Agent
 

--- a/src/modules/Nsswitch.rb
+++ b/src/modules/Nsswitch.rb
@@ -103,7 +103,7 @@ module Yast
     publish :function => :WriteAutofs, :type => "boolean (boolean, string)"
     publish :function => :Write, :type => "boolean ()"
 
-    private
+  private
 
     def cfa_model
       @cfa_model ||= CFA::Nsswitch.load


### PR DESCRIPTION
Add a function to query existing PAM modules. Needed for https://trello.com/c/ahoBngck/1948-5-ostumbleweed-p5-1171318-build-20200506-yast-security-module-integrate-with-pampwdquality and https://bugzilla.suse.com/show_bug.cgi?id=1171318 so that the YaST security module can work regardless of whether pam-cracklib or pam-pwquality is available.

Replacing the existing SCR calls by Yast::Execute is not possible without breaking testsuites, e.g. in yast2-security. Even changing from "-a" to "--add" has the same effect.