### PR TITLE
Fix a bug recently introduced in the Nsswitch module

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -48,7 +48,8 @@ Lint/UnusedMethodArgument:
 # Configuration parameters: CountComments, ExcludedMethods.
 # ExcludedMethods: refine
 Metrics/BlockLength:
-  Max: 120
+  Exclude:
+    - 'test/**/*'
 
 # Offense count: 3
 # Configuration parameters: ExpectMatchingDefinition, Regex, IgnoreExecutableScripts, AllowedAcronyms.

--- a/package/yast2-pam.changes
+++ b/package/yast2-pam.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jul 28 11:35:47 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Fixed a bug, introduced in the latest version, related to
+  deletion of nsswitch entries (related to bsc#1173119).
+- 4.3.2
+
+-------------------------------------------------------------------
 Tue Jul 28 11:03:14 CEST 2020 - aschnell@suse.com
 
 - Added function to query PAM modules (bsc#1171318).

--- a/package/yast2-pam.spec
+++ b/package/yast2-pam.spec
@@ -16,7 +16,7 @@
 #
 
 Name:          yast2-pam
-Version:       4.3.1
+Version:       4.3.2
 Release:       0
 Summary:       YaST2 - PAM Agent
 

--- a/src/modules/Nsswitch.rb
+++ b/src/modules/Nsswitch.rb
@@ -53,7 +53,12 @@ module Yast
     # @param db_name [String] database entry name, e.g. "passwd"
     # @param services [Array<String>] service specs, e.g. ["files", "nis"]
     def WriteDb(db_name, services)
-      cfa_model.update_entry(db_name, services)
+      # For improved compatibility with the old implementation, check also [""]
+      if services.empty? || services == [""]
+        cfa_model.delete_entry(db_name)
+      else
+        cfa_model.update_entry(db_name, services)
+      end
     end
 
     # Configures the name service switch for autofs according to chosen settings

--- a/src/modules/Nsswitch.rb
+++ b/src/modules/Nsswitch.rb
@@ -46,12 +46,15 @@ module Yast
     end
 
 
-    # Writes a database entry as a list to nsswitch_conf
+    # Writes a database entry as a list to nsswitch_conf or deletes an existing
+    # database entry
     #
     # @see CFA::Nsswitch#update_entry
+    # @see CFA::Nsswitch#delete_entry
     #
     # @param db_name [String] database entry name, e.g. "passwd"
-    # @param services [Array<String>] service specs, e.g. ["files", "nis"]
+    # @param services [Array<String>] use a valid service specs (e.g. ["files", "nis"])
+    #   to write an entry or an empty array to remove the existing entry
     def WriteDb(db_name, services)
       # For improved compatibility with the old implementation, check also [""]
       if services.empty? || services == [""]

--- a/test/nsswitch_test.rb
+++ b/test/nsswitch_test.rb
@@ -78,13 +78,33 @@ describe Yast::Nsswitch do
         expect(nsswitch.ReadDb("hosts")).to eq(["nis", "files"])
       end
 
-      context "when given not defined yet database entry" do
-        it "adds it to the configuration" do
+      context "if the service specification is an empty array" do
+        it "removes the database entry" do
+          expect(nsswitch.ReadDb("hosts")).to eq(["db", "files"])
+
+          nsswitch.WriteDb("hosts", [])
+
+          expect(nsswitch.ReadDb("hosts")).to eq([])
+        end
+      end
+    end
+
+    context "when given not defined yet database entry" do
+      it "adds it to the configuration" do
+        expect(nsswitch.ReadDb("ethers")).to eq([])
+
+        nsswitch.WriteDb("ethers", ["nis", "files"])
+
+        expect(nsswitch.ReadDb("ethers")).to eq(["nis", "files"])
+      end
+
+      context "if the service specification is an empty array" do
+        it "changes nothing" do
           expect(nsswitch.ReadDb("ethers")).to eq([])
 
-          nsswitch.WriteDb("ethers", ["nis", "files"])
+          nsswitch.WriteDb("ethers", [])
 
-          expect(nsswitch.ReadDb("ethers")).to eq(["nis", "files"])
+          expect(nsswitch.ReadDb("ethers")).to eq([])
         end
       end
     end
@@ -139,11 +159,18 @@ describe Yast::Nsswitch do
 
       it "writes changes to the file" do
         expect(File.read(file_path)).to_not match(/ethers:/)
+        expect(File.read(file_path)).to match(/hosts:/)
+        expect(File.read(file_path)).to_not match(/netmasks:/)
 
         nsswitch.WriteDb("ethers", ["nis", "files"])
+        # Test deleting entries
+        nsswitch.WriteDb("hosts", [])
+        nsswitch.WriteDb("netmasks", [])
         nsswitch.Write
 
         expect(File.read(file_path)).to match(/ethers:\s+nis files/)
+        expect(File.read(file_path)).to_not match(/hosts:/)
+        expect(File.read(file_path)).to_not match(/netmasks:/)
       end
     end
 


### PR DESCRIPTION
## Problem

This is a follow-up of #20. In that pull request the `Yast::Nsswitch` module was re-implemented to use `CFA::Nsswitch` internally.

But, although originally `Nsswitch.WriteDb("whatever", [])` used to remove the `whatever` db entry, that behavior got lost in the reimplementation. That breaks backwards compatibility... and produce serious problems when writing the file because an entry with an empty list as value is wrong.

## Solution

Recover the original behavior to restore backwards compatibility and prevent validation errors when finally writing the nsswitch.conf file.

## Testing

Added unit tests