### PR TITLE
Fix popup

### DIFF
--- a/package/yast2-pam.changes
+++ b/package/yast2-pam.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Feb 15 11:03:27 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
+
+- Adapted unit test to recent changes in Yast::Report (related to
+  bsc#1179893).
+- 4.3.4
+
+-------------------------------------------------------------------
 Wed Oct 14 12:42:35 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - Fix initialize of packager to not break command line

--- a/package/yast2-pam.spec
+++ b/package/yast2-pam.spec
@@ -16,7 +16,7 @@
 #
 
 Name:          yast2-pam
-Version:       4.3.3
+Version:       4.3.4
 Release:       0
 Summary:       YaST2 - PAM Agent
 

--- a/test/nsswitch_test.rb
+++ b/test/nsswitch_test.rb
@@ -175,6 +175,10 @@ describe Yast::Nsswitch do
     end
 
     context "when something is wrong" do
+      before do
+        allow(Yast::Report).to receive(:Error)
+      end
+
       it "returns false" do
         # there is not support for actions yet
         nsswitch.WriteDb("ethers", ["nis [NOTFOUND=return]", "files"])


### PR DESCRIPTION
This pull request in yast-yast2 (https://github.com/yast/yast-yast2/pull/1122) changed the behavior during unit tests of `Yast::Report` and `Yast2::Popup`, making necessary to add some extra mocking to prevent YaST from trying to open windows during the test execution.

As far as we know, that affected the test-suites of: yast-storage-ng, yast-country, yast-firewall, yast-nfs-server, yast-nis-client, yast-pam, yast-security, yast-services-manager and yast-sysconfig.

This should fix the problem for this repository.