### PR TITLE
simplify autologin module to depend only on Package module

### DIFF
--- a/src/modules/Autologin.rb
+++ b/src/modules/Autologin.rb
@@ -45,10 +45,6 @@ module Yast
 
       Yast.import "Package"
       Yast.import "Popup"
-      Yast.import "Pkg"
-      Yast.import "PackageCallbacks"
-      Yast.import "Installation"
-      Yast.import "Stage"
 
       # User to log in automaticaly
       @user = ""
@@ -180,8 +176,7 @@ module Yast
     #
     # @return Boolean
     def supported?
-      pkg_lazy_init
-      supported = DISPLAY_MANAGERS.any? { |dm| Pkg.IsSelected(dm) || Pkg.IsProvided(dm) }
+      supported = DISPLAY_MANAGERS.any? { |dm| Package.Available(dm) }
 
       if supported
         log.info("Autologin is supported")
@@ -191,26 +186,6 @@ module Yast
 
       supported
     end
-
-    # Initialize the pkg subsystem
-    def pkg_lazy_init
-      # do not initialize the package manager when running in inst-sys,
-      # it is initialized by the installation framework (bsc#1135295)
-      return if Stage.initial || @pkg_initialized
-
-      # We don't strictly need any package callbacks here, but libzypp might
-      # report an error, and then there would be no user feedback.
-      PackageCallbacks.InitPackageCallbacks
-      # FIXME: Mode.test workaround for the old testsuite to not break the other modules
-      Pkg.TargetInitialize(Installation.destdir) unless Mode.test
-
-      # Add the installed system to the libzypp pool
-      # FIXME: Mode.test workaround for the old testsuite to not break the other modules
-      Pkg.TargetLoad unless Mode.test
-
-      @pkg_initialized = true
-    end
-
 
     publish :variable => :user, :type => "string"
     publish :variable => :pw_less, :type => "boolean"

--- a/test/autologin_test.rb
+++ b/test/autologin_test.rb
@@ -1,0 +1,48 @@
+#!rspec
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "test_helper"
+
+Yast.import "Autologin"
+
+describe Yast::Autologin do
+  subject(:nsswitch) { Yast::Autologin }
+
+  before do
+    # reset module before each run
+    subject.main
+    allow(Yast::Package).to receive(:Available).and_return(false)
+  end
+
+  describe ".available" do
+    it "returns true if Read found a supported DM" do
+      allow(Yast::Package).to receive(:Available).with("gdm").and_return(true)
+
+      subject.Read
+      expect(subject.available).to eq true
+    end
+
+    it "returns true if Read did not find any supported DM" do
+      subject.Read
+      expect(subject.available).to eq false
+    end
+  end
+end
+


### PR DESCRIPTION
## Problem

Autologin module depends on low level Pkg methods which is in collision with POC to have multi process D-Bus services where communication should happen over D-Bus.


## Solution

Use well known methods from Package module that can be easily ask over D-Bus.


## Testing

- *Added a new unit test*
- *Tested manually*

